### PR TITLE
Introduce ThinArcList, ThinArcItem, and ThinItemWake

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triomphe"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>", "The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Manishearth/triomphe"

--- a/src/arc_borrow.rs
+++ b/src/arc_borrow.rs
@@ -4,6 +4,8 @@ use core::mem::ManuallyDrop;
 use core::ops::Deref;
 use core::ptr::NonNull;
 
+use crate::{ThinArcItem, ThinArcList, WithOffset};
+
 use super::Arc;
 
 /// A "borrowed `Arc`". This is a pointer to
@@ -138,10 +140,130 @@ unsafe impl<'lt, T: 'lt, U: ?Sized + 'lt> unsize::CoerciblePtr<U> for ArcBorrow<
     }
 }
 
+/// A "borrowed `ThinArcItem`". This is a pointer to
+/// a T that is known to have been allocated within an
+/// `ThinArcList`.
+///
+/// This is equivalent in guarantees to `&ThinArcItem<T>`, however it is
+/// a bit more flexible. To obtain an `&ThinArcItem<T>` you must have
+/// an `ThinArcItem<T>` instance somewhere pinned down until we're done with it.
+/// It's also a direct pointer to `T`, so using this involves less pointer-chasing
+///
+/// However, C++ code may hand us refcounted things as pointers to T directly,
+/// so we have to conjure up a temporary `ThinArcItem` on the stack each time.
+///
+/// `ArcItemBorrow` lets us deal with borrows of known-refcounted objects
+/// without needing to worry about where the `ThinArcItem<T>` is.
+#[derive(Debug, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct ArcItemBorrow<'a, H: 'a, T: 'a>(
+    pub(crate) NonNull<WithOffset<T>>,
+    pub(crate) PhantomData<&'a (H, T)>,
+);
+
+unsafe impl<'a, H: Sync + Send, T: Sync + Send> Send for ArcItemBorrow<'a, H, T> {}
+unsafe impl<'a, H: Sync + Send, T: Sync + Send> Sync for ArcItemBorrow<'a, H, T> {}
+
+impl<'a, H, T> Copy for ArcItemBorrow<'a, H, T> {}
+impl<'a, H, T> Clone for ArcItemBorrow<'a, H, T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, H, T> ArcItemBorrow<'a, H, T> {
+    /// Clone this as an `Arc<T>`. This bumps the refcount.
+    #[inline]
+    pub fn clone_arc(&self) -> ThinArcItem<H, T> {
+        self.with_arc(|a| a.clone())
+    }
+
+    // /// For constructing from a pointer known to be Arc-backed,
+    // /// e.g. if we obtain such a pointer over FFI
+    // ///
+    // // TODO: should from_ptr be relaxed to unsized types? It can't be
+    // // converted back to an Arc right now for unsized types.
+    // //
+    // /// # Safety
+    // /// - The pointer to `T` must have come from a Triomphe `Arc`, `UniqueArc`, or `ArcItemBorrow`.
+    // /// - The pointer to `T` must have full provenance over the `Arc`, `UniqueArc`, or `ArcItemBorrow`,
+    // ///   in particular it must not have been derived from a `&T` reference, as references immediately
+    // ///   loose all provenance over the adjacent reference counts. As of this writing,
+    // ///   of the 3 types, only Trimphe's `Arc` offers a direct API for obtaining such a pointer:
+    // ///   [`Arc::as_ptr`].
+    // #[inline]
+    // pub unsafe fn from_ptr(ptr: *const T) -> Self {
+    //     unsafe { ArcItemBorrow(NonNull::new_unchecked(ptr as *mut T), PhantomData) }
+    // }
+
+    /// Compare two `ArcItemBorrow`s via pointer equality. Will only return
+    /// true if they come from the same allocation
+    #[inline]
+    pub fn ptr_eq(this: &Self, other: &Self) -> bool {
+        this.0 == other.0
+    }
+
+    /// The reference count of the underlying `Arc`.
+    ///
+    /// The number does not include borrowed pointers,
+    /// or temporary `Arc` pointers created with functions like
+    /// [`ArcItemBorrow::with_arc`].
+    ///
+    /// The function is called `strong_count` to mirror `std::sync::Arc::strong_count`,
+    /// however `triomphe::Arc` does not support weak references.
+    #[inline]
+    pub fn strong_count(this: &Self) -> usize {
+        Self::with_arc(this, |arc| {
+            arc.with_parent(|arc| arc.with_arc(Arc::strong_count))
+        })
+    }
+
+    /// Temporarily converts |self| into a bonafide Arc and exposes it to the
+    /// provided callback. The refcount is not modified.
+    #[inline]
+    pub fn with_arc<F, U>(&self, f: F) -> U
+    where
+        F: FnOnce(&ThinArcItem<H, T>) -> U,
+    {
+        // Synthesize transient Arc, which never touches the refcount.
+        let transient = unsafe { ManuallyDrop::new(ThinArcItem::from_raw(self.0)) };
+
+        // Expose the transient Arc to the callback, which may clone it if it wants
+        // and forward the result to the user
+        f(&transient)
+    }
+
+    /// Similar to deref, but uses the lifetime |a| rather than the lifetime of
+    /// self, which is incompatible with the signature of the Deref trait.
+    #[inline]
+    pub fn get(&self) -> &'a T {
+        unsafe { &(*self.0.as_ptr()).value }
+    }
+}
+
+impl<'a, H, T> Deref for ArcItemBorrow<'a, H, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        self.get()
+    }
+}
+
 #[test]
 fn clone_arc_borrow() {
     let x = Arc::new(42);
     let b: ArcBorrow<'_, i32> = x.borrow_arc();
     let y = b.clone_arc();
     assert_eq!(x, y);
+}
+
+#[test]
+fn clone_arc_item_borrow() {
+    let x = ThinArcList::from_header_and_iter(42, std::iter::once(43));
+    let y = x.with_item(0, |x| x.clone());
+    let b: ArcItemBorrow<'_, i32, i32> = y.borrow_arc();
+    let z = b.clone_arc();
+    assert_eq!(y, z);
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -25,9 +25,10 @@ pub struct HeaderSlice<H, T: ?Sized> {
 impl<H, T> Arc<HeaderSlice<H, [T]>> {
     /// Creates an Arc for a HeaderSlice using the given header struct and
     /// iterator to generate the slice. The resulting Arc will be fat.
-    pub fn from_header_and_iter<I>(header: H, mut items: I) -> Self
+    pub fn header_from_iter<I, F>(mut items: I, f: F) -> Self
     where
         I: Iterator<Item = T> + ExactSizeIterator,
+        F: FnOnce(&mut [T]) -> H,
     {
         assert_ne!(mem::size_of::<T>(), 0, "Need to think about ZST");
 
@@ -40,7 +41,6 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
             //
             // Note that any panics here (i.e. from the iterator) are safe, since
             // we'll just leak the uninitialized memory.
-            ptr::write(&mut ((*inner.as_ptr()).data.header), header);
             let mut current = (*inner.as_ptr()).data.slice.as_mut_ptr();
             for _ in 0..num_items {
                 ptr::write(
@@ -55,6 +55,9 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
                 items.next().is_none(),
                 "ExactSizeIterator under-reported length"
             );
+
+            let header = f(&mut (*inner.as_ptr()).data.slice);
+            ptr::write(&mut ((*inner.as_ptr()).data.header), header);
         }
 
         // Safety: ptr is valid & the inner structure is fully initialized
@@ -62,6 +65,15 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
             p: inner,
             phantom: PhantomData,
         }
+    }
+
+    /// Creates an Arc for a HeaderSlice using the given header struct and
+    /// iterator to generate the slice. The resulting Arc will be fat.
+    pub fn from_header_and_iter<I>(header: H, items: I) -> Self
+    where
+        I: Iterator<Item = T> + ExactSizeIterator,
+    {
+        Self::header_from_iter(items, |_| header)
     }
 
     /// Creates an Arc for a HeaderSlice using the given header struct and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ mod arc_union;
 mod header;
 mod iterator_as_exact_size_iterator;
 mod offset_arc;
+pub mod task;
 mod thin_arc;
 mod thin_arc_list;
 mod unique_arc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ mod header;
 mod iterator_as_exact_size_iterator;
 mod offset_arc;
 mod thin_arc;
+mod thin_arc_list;
 mod unique_arc;
 
 pub use arc::*;
@@ -52,6 +53,7 @@ pub use arc_union::*;
 pub use header::*;
 pub use offset_arc::*;
 pub use thin_arc::*;
+pub use thin_arc_list::*;
 pub use unique_arc::*;
 
 #[cfg(feature = "std")]

--- a/src/task.rs
+++ b/src/task.rs
@@ -6,7 +6,7 @@ use core::{
     task::{RawWaker, RawWakerVTable, Waker},
 };
 
-use crate::ThinArcItem;
+use crate::{ArcItemBorrow, ThinArcItem};
 
 pub trait ThinItemWake<H>: Sized {
     fn wake(this: ThinArcItem<H, Self>) {
@@ -16,7 +16,6 @@ pub trait ThinItemWake<H>: Sized {
     fn wake_by_ref(this: &ThinArcItem<H, Self>);
 }
 
-#[cfg(target_has_atomic = "ptr")]
 impl<H: 'static, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for Waker {
     /// Use a [`Wake`]-able type as a `Waker`.
     ///
@@ -24,28 +23,34 @@ impl<H: 'static, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H,
     fn from(waker: ThinArcItem<H, W>) -> Waker {
         // SAFETY: This is safe because raw_waker safely constructs
         // a RawWaker from ThinArcItem<H, W>.
-        unsafe { Waker::from_raw(raw_waker(waker)) }
+        unsafe { Waker::from_raw(RawWaker::from(waker)) }
     }
 }
 
-#[cfg(target_has_atomic = "ptr")]
 impl<H: 'static, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for RawWaker {
     /// Use a `Wake`-able type as a `RawWaker`.
     ///
     /// No heap allocations or atomic operations are used for this conversion.
     fn from(waker: ThinArcItem<H, W>) -> RawWaker {
-        raw_waker(waker)
+        RawWaker::new(waker.into_raw().as_ptr().cast(), waker_vtable::<H, W>())
     }
 }
 
-#[cfg(target_has_atomic = "ptr")]
 impl<'a, H: 'static, W: ThinItemWake<H> + Send + Sync + 'static> From<&'a ThinArcItem<H, W>>
     for WakerRef<'a>
 {
     fn from(waker: &'a ThinArcItem<H, W>) -> WakerRef<'a> {
+        Self::from(waker.borrow_arc())
+    }
+}
+
+impl<'a, H: 'static, W: ThinItemWake<H> + Send + Sync + 'static> From<ArcItemBorrow<'a, H, W>>
+    for WakerRef<'a>
+{
+    fn from(waker: ArcItemBorrow<'a, H, W>) -> WakerRef<'a> {
         let waker = ManuallyDrop::new(unsafe {
             Waker::from_raw(RawWaker::new(
-                waker.as_raw().as_ptr().cast(),
+                waker.0.as_ptr().cast(),
                 waker_vtable::<H, W>(),
             ))
         });
@@ -91,11 +96,6 @@ fn waker_vtable<H, W: ThinItemWake<H> + Send + Sync + 'static>() -> &'static Raw
         wake_by_ref::<H, W>,
         drop_waker::<H, W>,
     )
-}
-
-#[inline(always)]
-fn raw_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: ThinArcItem<H, W>) -> RawWaker {
-    RawWaker::new(waker.into_raw().as_ptr().cast(), waker_vtable::<H, W>())
 }
 
 /// A [`Waker`] that is only valid for a given lifetime.

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,90 @@
+use core::task::{RawWaker, Waker};
+
+use crate::ThinArcItem;
+
+pub trait ThinItemWake<H>: Sized {
+    fn wake(this: ThinArcItem<H, Self>) {
+        Self::wake_by_ref(&this);
+    }
+
+    fn wake_by_ref(this: &ThinArcItem<H, Self>);
+}
+
+#[cfg(target_has_atomic = "ptr")]
+impl<H, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for Waker {
+    /// Use a [`Wake`]-able type as a `Waker`.
+    ///
+    /// No heap allocations or atomic operations are used for this conversion.
+    fn from(waker: ThinArcItem<H, W>) -> Waker {
+        // SAFETY: This is safe because raw_waker safely constructs
+        // a RawWaker from ThinArcItem<H, W>.
+        unsafe { Waker::from_raw(raw_waker(waker)) }
+    }
+}
+
+#[cfg(target_has_atomic = "ptr")]
+impl<H, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for RawWaker {
+    /// Use a `Wake`-able type as a `RawWaker`.
+    ///
+    /// No heap allocations or atomic operations are used for this conversion.
+    fn from(waker: ThinArcItem<H, W>) -> RawWaker {
+        raw_waker(waker)
+    }
+}
+
+// NB: This private function for constructing a RawWaker is used, rather than
+// inlining this into the `From<ThinArcItem<H, W>> for RawWaker` impl, to ensure that
+// the safety of `From<ThinArcItem<H, W>> for Waker` does not depend on the correct
+// trait dispatch - instead both impls call this function directly and
+// explicitly.
+#[cfg(target_has_atomic = "ptr")]
+#[inline(always)]
+fn raw_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: ThinArcItem<H, W>) -> RawWaker {
+    use core::{
+        mem::ManuallyDrop,
+        ptr::NonNull,
+        task::{RawWaker, RawWakerVTable},
+    };
+
+    fn vtable<H, W: ThinItemWake<H> + Send + Sync + 'static>() -> &'static RawWakerVTable {
+        &RawWakerVTable::new(
+            clone_waker::<H, W>,
+            wake::<H, W>,
+            wake_by_ref::<H, W>,
+            drop_waker::<H, W>,
+        )
+    }
+
+    // Increment the reference count of the arc to clone it.
+    unsafe fn clone_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(
+        waker: *const (),
+    ) -> RawWaker {
+        let waker_ptr = unsafe { NonNull::new_unchecked(waker.cast_mut().cast()) };
+        let waker_ref = unsafe { ThinArcItem::<H, W>::from_raw_ref(waker_ptr) };
+        let _clone = ManuallyDrop::new(waker_ref.clone());
+
+        RawWaker::new(waker, vtable::<H, W>())
+    }
+
+    // Wake by value, moving the Arc into the Wake::wake function
+    unsafe fn wake<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: *const ()) {
+        let waker_ptr = unsafe { NonNull::new_unchecked(waker.cast_mut().cast()) };
+        let waker = unsafe { ThinArcItem::from_raw(waker_ptr) };
+        <W as ThinItemWake<H>>::wake(waker);
+    }
+
+    // Wake by reference, wrap the waker in ManuallyDrop to avoid dropping it
+    unsafe fn wake_by_ref<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: *const ()) {
+        let waker_ptr = unsafe { NonNull::new_unchecked(waker.cast_mut().cast()) };
+        let waker_ref = unsafe { ThinArcItem::<H, W>::from_raw_ref(waker_ptr) };
+        <W as ThinItemWake<H>>::wake_by_ref(&waker_ref);
+    }
+
+    // Decrement the reference count of the Arc on drop
+    unsafe fn drop_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: *const ()) {
+        let waker_ptr = unsafe { NonNull::new_unchecked(waker.cast_mut().cast()) };
+        let _ = unsafe { ThinArcItem::<H, W>::from_raw(waker_ptr) };
+    }
+
+    RawWaker::new(waker.into_raw().as_ptr().cast(), vtable::<H, W>())
+}

--- a/src/task.rs
+++ b/src/task.rs
@@ -41,7 +41,6 @@ impl<H, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for 
 #[inline(always)]
 fn raw_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: ThinArcItem<H, W>) -> RawWaker {
     use core::{
-        mem::ManuallyDrop,
         ptr::NonNull,
         task::{RawWaker, RawWakerVTable},
     };
@@ -61,9 +60,9 @@ fn raw_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: ThinArcItem<H
     ) -> RawWaker {
         let waker_ptr = unsafe { NonNull::new_unchecked(waker.cast_mut().cast()) };
         let waker_ref = unsafe { ThinArcItem::<H, W>::from_raw_ref(waker_ptr) };
-        let _clone = ManuallyDrop::new(waker_ref.clone());
+        let waker = waker_ref.clone_arc().into_raw();
 
-        RawWaker::new(waker, vtable::<H, W>())
+        RawWaker::new(waker.as_ptr().cast(), vtable::<H, W>())
     }
 
     // Wake by value, moving the Arc into the Wake::wake function
@@ -77,7 +76,7 @@ fn raw_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: ThinArcItem<H
     unsafe fn wake_by_ref<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: *const ()) {
         let waker_ptr = unsafe { NonNull::new_unchecked(waker.cast_mut().cast()) };
         let waker_ref = unsafe { ThinArcItem::<H, W>::from_raw_ref(waker_ptr) };
-        <W as ThinItemWake<H>>::wake_by_ref(&waker_ref);
+        waker_ref.with_arc(|a| <W as ThinItemWake<H>>::wake_by_ref(a))
     }
 
     // Decrement the reference count of the Arc on drop

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,4 +1,10 @@
-use core::task::{RawWaker, Waker};
+use core::{
+    marker::PhantomData,
+    mem::ManuallyDrop,
+    ops::Deref,
+    ptr::NonNull,
+    task::{RawWaker, RawWakerVTable, Waker},
+};
 
 use crate::ThinArcItem;
 
@@ -11,7 +17,7 @@ pub trait ThinItemWake<H>: Sized {
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<H, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for Waker {
+impl<H: 'static, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for Waker {
     /// Use a [`Wake`]-able type as a `Waker`.
     ///
     /// No heap allocations or atomic operations are used for this conversion.
@@ -23,7 +29,7 @@ impl<H, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for 
 }
 
 #[cfg(target_has_atomic = "ptr")]
-impl<H, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for RawWaker {
+impl<H: 'static, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for RawWaker {
     /// Use a `Wake`-able type as a `RawWaker`.
     ///
     /// No heap allocations or atomic operations are used for this conversion.
@@ -32,28 +38,22 @@ impl<H, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for 
     }
 }
 
-// NB: This private function for constructing a RawWaker is used, rather than
-// inlining this into the `From<ThinArcItem<H, W>> for RawWaker` impl, to ensure that
-// the safety of `From<ThinArcItem<H, W>> for Waker` does not depend on the correct
-// trait dispatch - instead both impls call this function directly and
-// explicitly.
 #[cfg(target_has_atomic = "ptr")]
-#[inline(always)]
-fn raw_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: ThinArcItem<H, W>) -> RawWaker {
-    use core::{
-        ptr::NonNull,
-        task::{RawWaker, RawWakerVTable},
-    };
-
-    fn vtable<H, W: ThinItemWake<H> + Send + Sync + 'static>() -> &'static RawWakerVTable {
-        &RawWakerVTable::new(
-            clone_waker::<H, W>,
-            wake::<H, W>,
-            wake_by_ref::<H, W>,
-            drop_waker::<H, W>,
-        )
+impl<'a, H: 'static, W: ThinItemWake<H> + Send + Sync + 'static> From<&'a ThinArcItem<H, W>>
+    for WakerRef<'a>
+{
+    fn from(waker: &'a ThinArcItem<H, W>) -> WakerRef<'a> {
+        let waker = ManuallyDrop::new(unsafe {
+            Waker::from_raw(RawWaker::new(
+                waker.as_raw().as_ptr().cast(),
+                waker_vtable::<H, W>(),
+            ))
+        });
+        WakerRef::new_unowned(waker)
     }
+}
 
+fn waker_vtable<H, W: ThinItemWake<H> + Send + Sync + 'static>() -> &'static RawWakerVTable {
     // Increment the reference count of the arc to clone it.
     unsafe fn clone_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(
         waker: *const (),
@@ -62,7 +62,7 @@ fn raw_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: ThinArcItem<H
         let waker_ref = unsafe { ThinArcItem::<H, W>::from_raw_ref(waker_ptr) };
         let waker = waker_ref.clone_arc().into_raw();
 
-        RawWaker::new(waker.as_ptr().cast(), vtable::<H, W>())
+        RawWaker::new(waker.as_ptr().cast(), waker_vtable::<H, W>())
     }
 
     // Wake by value, moving the Arc into the Wake::wake function
@@ -85,5 +85,62 @@ fn raw_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: ThinArcItem<H
         let _ = unsafe { ThinArcItem::<H, W>::from_raw(waker_ptr) };
     }
 
-    RawWaker::new(waker.into_raw().as_ptr().cast(), vtable::<H, W>())
+    &RawWakerVTable::new(
+        clone_waker::<H, W>,
+        wake::<H, W>,
+        wake_by_ref::<H, W>,
+        drop_waker::<H, W>,
+    )
+}
+
+#[inline(always)]
+fn raw_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: ThinArcItem<H, W>) -> RawWaker {
+    RawWaker::new(waker.into_raw().as_ptr().cast(), waker_vtable::<H, W>())
+}
+
+/// A [`Waker`] that is only valid for a given lifetime.
+///
+/// Note: this type implements [`Deref<Target = Waker>`](std::ops::Deref),
+/// so it can be used to get a `&Waker`.
+#[derive(Debug)]
+pub struct WakerRef<'a> {
+    waker: ManuallyDrop<Waker>,
+    _marker: PhantomData<&'a ()>,
+}
+
+impl<'a> WakerRef<'a> {
+    /// Create a new [`WakerRef`] from a [`Waker`] reference.
+    #[inline]
+    pub fn new(waker: &'a Waker) -> Self {
+        // copy the underlying (raw) waker without calling a clone,
+        // as we won't call Waker::drop either.
+        let waker = ManuallyDrop::new(unsafe { core::ptr::read(waker) });
+        Self {
+            waker,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Create a new [`WakerRef`] from a [`Waker`] that must not be dropped.
+    ///
+    /// Note: this if for rare cases where the caller created a [`Waker`] in
+    /// an unsafe way (that will be valid only for a lifetime to be determined
+    /// by the caller), and the [`Waker`] doesn't need to or must not be
+    /// destroyed.
+    #[inline]
+    pub fn new_unowned(waker: ManuallyDrop<Waker>) -> Self {
+        Self {
+            waker,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl Deref for WakerRef<'_> {
+    type Target = Waker;
+
+    #[inline]
+    fn deref(&self) -> &Waker {
+        &self.waker
+    }
 }

--- a/src/thin_arc.rs
+++ b/src/thin_arc.rs
@@ -40,7 +40,7 @@ pub struct ThinArc<H, T> {
     // The safe API of `ThinArc` ensures that the length in the `HeaderWithLength`
     // corretcly set - or verified - upon creation of a `ThinArc` and can't be modified
     // to fall out of sync with the true slice length for this value & allocation.
-    ptr: ptr::NonNull<ArcInner<HeaderSlice<HeaderWithLength<H>, [T; 0]>>>,
+    pub(super) ptr: ptr::NonNull<ArcInner<HeaderSlice<HeaderWithLength<H>, [T; 0]>>>,
     phantom: PhantomData<(H, T)>,
 }
 
@@ -143,6 +143,19 @@ impl<H, T> ThinArc<H, T> {
         );
 
         ret
+    }
+
+    /// Creates a `ThinArc` for a HeaderSlice using the given header struct and
+    /// iterator to generate the slice.
+    pub fn header_from_iter<I, F>(items: I, f: F) -> Self
+    where
+        I: Iterator<Item = T> + ExactSizeIterator,
+        F: FnOnce(&mut [T]) -> H,
+    {
+        let len = items.len();
+        Arc::into_thin(Arc::header_from_iter(items, |i| {
+            HeaderWithLength::new(f(i), len)
+        }))
     }
 
     /// Creates a `ThinArc` for a HeaderSlice using the given header struct and

--- a/src/thin_arc_list.rs
+++ b/src/thin_arc_list.rs
@@ -1,9 +1,14 @@
 use core::{
+    cmp::Ordering,
+    fmt,
+    hash::{Hash, Hasher},
     marker::PhantomData,
     mem::{self, offset_of, ManuallyDrop},
     ops::Deref,
     ptr::{self, NonNull},
 };
+
+use crate::{ArcItemBorrow, HeaderSliceWithLengthUnchecked};
 
 use super::{Arc, ArcInner, HeaderSlice, HeaderWithLength, ThinArc};
 
@@ -91,6 +96,16 @@ impl<H, T> ThinArcList<H, T> {
         });
         f(&transient)
     }
+
+    /// Temporarily converts |self| into a bonafide Arc and exposes it to the
+    /// provided callback. The refcount is not modified.
+    #[inline]
+    pub fn with_arc<F, U>(&self, f: F) -> U
+    where
+        F: FnOnce(&Arc<HeaderSliceWithLengthUnchecked<H, WithOffset<T>>>) -> U,
+    {
+        self.inner.with_arc(f)
+    }
 }
 
 impl<H, T> ThinArcItem<H, T> {
@@ -113,12 +128,17 @@ impl<H, T> ThinArcItem<H, T> {
 
     /// # Safety
     /// * Must come from as_ref, must have the same H.
-    /// * Must not be dropped.
-    pub unsafe fn from_raw_ref(ptr: NonNull<WithOffset<T>>) -> ManuallyDrop<Self> {
-        ManuallyDrop::new(Self {
-            ptr,
-            phantom: PhantomData,
-        })
+    pub unsafe fn from_raw_ref<'a>(ptr: NonNull<WithOffset<T>>) -> ArcItemBorrow<'a, H, T> {
+        ArcItemBorrow(ptr, PhantomData)
+    }
+
+    /// Produce a pointer to the data that can be converted back
+    /// to an ThinArcItem. This is basically an `&ThinArcItem<T>`, without the extra indirection.
+    /// It has the benefits of an `&T` but also knows about the underlying refcount
+    /// and can be converted into more `ThinArcItem<T>`s if necessary.
+    #[inline]
+    pub fn borrow_arc(&self) -> ArcItemBorrow<'_, H, T> {
+        ArcItemBorrow(self.ptr, PhantomData)
     }
 
     pub fn index(&self) -> usize {
@@ -199,5 +219,71 @@ impl<H, T> Drop for ThinArcItem<H, T> {
     #[inline]
     fn drop(&mut self) {
         let _ = unsafe { self.ref_into_parent() };
+    }
+}
+
+impl<H, T: PartialEq> PartialEq for ThinArcItem<H, T> {
+    fn eq(&self, other: &ThinArcItem<H, T>) -> bool {
+        // TODO: pointer equality is incorrect if `T` is not `Eq`.
+        self.ptr == other.ptr || *(*self) == *(*other)
+    }
+
+    #[allow(clippy::partialeq_ne_impl)]
+    fn ne(&self, other: &ThinArcItem<H, T>) -> bool {
+        self.ptr != other.ptr && *(*self) != *(*other)
+    }
+}
+
+impl<H, T: PartialOrd> PartialOrd for ThinArcItem<H, T> {
+    fn partial_cmp(&self, other: &ThinArcItem<H, T>) -> Option<Ordering> {
+        (**self).partial_cmp(&**other)
+    }
+
+    fn lt(&self, other: &ThinArcItem<H, T>) -> bool {
+        *(*self) < *(*other)
+    }
+
+    fn le(&self, other: &ThinArcItem<H, T>) -> bool {
+        *(*self) <= *(*other)
+    }
+
+    fn gt(&self, other: &ThinArcItem<H, T>) -> bool {
+        *(*self) > *(*other)
+    }
+
+    fn ge(&self, other: &ThinArcItem<H, T>) -> bool {
+        *(*self) >= *(*other)
+    }
+}
+
+impl<H, T: Ord> Ord for ThinArcItem<H, T> {
+    fn cmp(&self, other: &ThinArcItem<H, T>) -> Ordering {
+        (**self).cmp(&**other)
+    }
+}
+
+impl<H, T: Eq> Eq for ThinArcItem<H, T> {}
+
+impl<H, T: fmt::Display> fmt::Display for ThinArcItem<H, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+impl<H, T: fmt::Debug> fmt::Debug for ThinArcItem<H, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<H, T> fmt::Pointer for ThinArcItem<H, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Pointer::fmt(&self.ptr, f)
+    }
+}
+
+impl<H, T: Hash> Hash for ThinArcItem<H, T> {
+    fn hash<Ha: Hasher>(&self, state: &mut Ha) {
+        (**self).hash(state)
     }
 }

--- a/src/thin_arc_list.rs
+++ b/src/thin_arc_list.rs
@@ -94,6 +94,19 @@ impl<H, T> ThinArcList<H, T> {
 }
 
 impl<H, T> ThinArcItem<H, T> {
+    pub fn into_raw(self) -> NonNull<WithOffset<T>> {
+        ManuallyDrop::new(self).ptr
+    }
+
+    /// # Safety
+    /// * Must come from as_ref, must have the same H.
+    pub unsafe fn from_raw(ptr: NonNull<WithOffset<T>>) -> Self {
+        Self {
+            ptr,
+            phantom: PhantomData,
+        }
+    }
+
     pub fn as_raw(&self) -> NonNull<WithOffset<T>> {
         self.ptr
     }
@@ -186,130 +199,5 @@ impl<H, T> Drop for ThinArcItem<H, T> {
     #[inline]
     fn drop(&mut self) {
         let _ = unsafe { self.ref_into_parent() };
-    }
-}
-
-pub mod wake {
-    use super::*;
-    use core::task::{RawWaker, Waker};
-
-    pub trait ThinItemWake<H>: Sized {
-        fn wake(this: ThinArcItem<H, Self>) {
-            Self::wake_by_ref(&this);
-        }
-
-        fn wake_by_ref(this: &ThinArcItem<H, Self>);
-    }
-
-    #[cfg(target_has_atomic = "ptr")]
-    impl<H, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for Waker {
-        /// Use a [`Wake`]-able type as a `Waker`.
-        ///
-        /// No heap allocations or atomic operations are used for this conversion.
-        fn from(waker: ThinArcItem<H, W>) -> Waker {
-            // SAFETY: This is safe because raw_waker safely constructs
-            // a RawWaker from ThinArcItem<H, W>.
-            unsafe { Waker::from_raw(raw_waker(waker)) }
-        }
-    }
-
-    #[cfg(target_has_atomic = "ptr")]
-    impl<H, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for RawWaker {
-        /// Use a `Wake`-able type as a `RawWaker`.
-        ///
-        /// No heap allocations or atomic operations are used for this conversion.
-        fn from(waker: ThinArcItem<H, W>) -> RawWaker {
-            raw_waker(waker)
-        }
-    }
-
-    // NB: This private function for constructing a RawWaker is used, rather than
-    // inlining this into the `From<ThinArcItem<H, W>> for RawWaker` impl, to ensure that
-    // the safety of `From<ThinArcItem<H, W>> for Waker` does not depend on the correct
-    // trait dispatch - instead both impls call this function directly and
-    // explicitly.
-    #[cfg(target_has_atomic = "ptr")]
-    #[inline(always)]
-    fn raw_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(
-        waker: ThinArcItem<H, W>,
-    ) -> RawWaker {
-        use core::{
-            ptr::NonNull,
-            task::{RawWaker, RawWakerVTable},
-        };
-
-        // Increment the reference count of the arc to clone it.
-        //
-        // The #[inline(always)] is to ensure that raw_waker and clone_waker are
-        // always generated in the same code generation unit as one another, and
-        // therefore that the structurally identical const-promoted RawWakerVTable
-        // within both functions is deduplicated at LLVM IR code generation time.
-        // This allows optimizing Waker::will_wake to a single pointer comparison of
-        // the vtable pointers, rather than comparing all four function pointers
-        // within the vtables.
-        #[inline(always)]
-        unsafe fn clone_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(
-            waker: *const (),
-        ) -> RawWaker {
-            let waker_ref = unsafe {
-                ManuallyDrop::new(ThinArcItem::<H, W> {
-                    ptr: NonNull::new_unchecked(waker.cast::<WithOffset<W>>().cast_mut()),
-                    phantom: PhantomData,
-                })
-            };
-            let _clone = ManuallyDrop::new(waker_ref.clone());
-
-            RawWaker::new(
-                waker,
-                &RawWakerVTable::new(
-                    clone_waker::<H, W>,
-                    wake::<H, W>,
-                    wake_by_ref::<H, W>,
-                    drop_waker::<H, W>,
-                ),
-            )
-        }
-
-        // Wake by value, moving the Arc into the Wake::wake function
-        unsafe fn wake<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: *const ()) {
-            let waker = unsafe {
-                ThinArcItem::<H, W> {
-                    ptr: NonNull::new_unchecked(waker.cast::<WithOffset<W>>().cast_mut()),
-                    phantom: PhantomData,
-                }
-            };
-            <W as ThinItemWake<H>>::wake(waker);
-        }
-
-        // Wake by reference, wrap the waker in ManuallyDrop to avoid dropping it
-        unsafe fn wake_by_ref<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: *const ()) {
-            let waker = unsafe {
-                ManuallyDrop::new(ThinArcItem::<H, W> {
-                    ptr: NonNull::new_unchecked(waker.cast::<WithOffset<W>>().cast_mut()),
-                    phantom: PhantomData,
-                })
-            };
-            <W as ThinItemWake<H>>::wake_by_ref(&waker);
-        }
-
-        // Decrement the reference count of the Arc on drop
-        unsafe fn drop_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: *const ()) {
-            let _ = unsafe {
-                ThinArcItem::<H, W> {
-                    ptr: NonNull::new_unchecked(waker.cast::<WithOffset<W>>().cast_mut()),
-                    phantom: PhantomData,
-                }
-            };
-        }
-
-        RawWaker::new(
-            ManuallyDrop::new(waker).ptr.as_ptr().cast(),
-            &RawWakerVTable::new(
-                clone_waker::<H, W>,
-                wake::<H, W>,
-                wake_by_ref::<H, W>,
-                drop_waker::<H, W>,
-            ),
-        )
     }
 }

--- a/src/thin_arc_list.rs
+++ b/src/thin_arc_list.rs
@@ -1,0 +1,315 @@
+use core::{
+    marker::PhantomData,
+    mem::{self, offset_of, ManuallyDrop},
+    ops::Deref,
+    ptr::{self, NonNull},
+};
+
+use super::{Arc, ArcInner, HeaderSlice, HeaderWithLength, ThinArc};
+
+#[derive(Clone, Copy)]
+pub struct WithOffset<T> {
+    /// the offset in the `ThinArcList` this value is stored
+    offset: usize,
+    /// the value stored
+    pub value: T,
+}
+
+#[repr(transparent)]
+pub struct ThinArcItem<H, T> {
+    ptr: ptr::NonNull<WithOffset<T>>,
+    phantom: PhantomData<ThinArcList<H, T>>,
+}
+
+impl<H, T> Deref for ThinArcItem<H, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &self.ptr.as_ref().value }
+    }
+}
+
+unsafe impl<H: Sync + Send, T: Sync + Send> Send for ThinArcItem<H, T> {}
+unsafe impl<H: Sync + Send, T: Sync + Send> Sync for ThinArcItem<H, T> {}
+
+#[repr(transparent)]
+pub struct ThinArcList<H, T> {
+    inner: ThinArc<H, WithOffset<T>>,
+}
+
+impl<H, T> ThinArcList<H, T> {
+    /// Creates a `ThinArc` for a HeaderSlice using the given header struct and
+    /// iterator to generate the slice.
+    pub fn header_from_iter<I, F>(items: I, f: F) -> Self
+    where
+        I: Iterator<Item = T> + ExactSizeIterator,
+        F: FnOnce(&mut [WithOffset<T>]) -> H,
+    {
+        Self {
+            inner: ThinArc::header_from_iter(
+                items
+                    .enumerate()
+                    .map(|(offset, value)| WithOffset { offset, value }),
+                f,
+            ),
+        }
+    }
+
+    /// Creates a `ThinArcList` for a HeaderSlice using the given header struct and
+    /// iterator to generate the slice.
+    pub fn from_header_and_iter<I>(header: H, items: I) -> Self
+    where
+        I: Iterator<Item = T> + ExactSizeIterator,
+    {
+        Self {
+            inner: ThinArc::from_header_and_iter(
+                header,
+                items
+                    .enumerate()
+                    .map(|(offset, value)| WithOffset { offset, value }),
+            ),
+        }
+    }
+
+    pub fn header(&self) -> &H {
+        &self.inner.header.header
+    }
+
+    pub fn with_item<F, U>(&self, index: usize, f: F) -> U
+    where
+        F: FnOnce(&ThinArcItem<H, T>) -> U,
+    {
+        // very fiddly :(
+        let len = unsafe { (*self.inner.ptr.as_ptr()).data.header.length };
+        assert!(index < len);
+        let slice =
+            unsafe { ptr::addr_of!((*self.inner.ptr.as_ptr()).data.slice).cast::<WithOffset<T>>() };
+
+        let transient = ManuallyDrop::new(ThinArcItem {
+            ptr: unsafe { NonNull::new_unchecked(slice.add(index).cast_mut()) },
+            phantom: PhantomData,
+        });
+        f(&transient)
+    }
+}
+
+impl<H, T> ThinArcItem<H, T> {
+    pub fn as_raw(&self) -> NonNull<WithOffset<T>> {
+        self.ptr
+    }
+
+    /// # Safety
+    /// * Must come from as_ref, must have the same H.
+    /// * Must not be dropped.
+    pub unsafe fn from_raw_ref(ptr: NonNull<WithOffset<T>>) -> ManuallyDrop<Self> {
+        ManuallyDrop::new(Self {
+            ptr,
+            phantom: PhantomData,
+        })
+    }
+
+    pub fn index(&self) -> usize {
+        unsafe { self.ptr.as_ref().offset }
+    }
+
+    pub fn with_parent<F, U>(&self, f: F) -> U
+    where
+        F: FnOnce(&ThinArcList<H, T>) -> U,
+    {
+        unsafe {
+            let transient = ManuallyDrop::new(self.ref_into_parent());
+            f(&transient)
+        }
+    }
+
+    unsafe fn ref_into_parent(&self) -> ThinArcList<H, T> {
+        let value_ptr = self.ptr.as_ptr().cast_const();
+        let offset = unsafe { (*value_ptr).offset };
+
+        // inner.data.slice[offset] -> inner.data.slice[0]
+        let slice_root = unsafe { value_ptr.sub(offset) };
+
+        let slice_offset = offset_of!(
+            ArcInner<HeaderSlice<HeaderWithLength<H>, [WithOffset<T>; 0]>>,
+            data.slice
+        );
+
+        // inner.data.slice[0] -> inner
+        let arc = unsafe {
+            slice_root
+                .byte_sub(slice_offset)
+                .cast::<ArcInner<HeaderSlice<HeaderWithLength<H>, [WithOffset<T>; 0]>>>()
+        };
+
+        // inner -> inner.data.header.length
+        let len = unsafe { *ptr::addr_of!((*arc).data.header.length) };
+
+        // Synthesize the fat pointer. We do this by claiming we have a direct
+        // pointer to a [T], and then changing the type of the borrow. The key
+        // point here is that the length portion of the fat pointer applies
+        // only to the number of elements in the dynamically-sized portion of
+        // the type, so the value will be the same whether it points to a [T]
+        // or something else with a [T] as its last member.
+        let fake_slice = ptr::slice_from_raw_parts_mut(arc as *mut WithOffset<T>, len);
+        let arc_slice =
+            fake_slice as *mut ArcInner<HeaderSlice<HeaderWithLength<H>, [WithOffset<T>]>>;
+
+        unsafe {
+            ThinArcList {
+                inner: Arc::into_thin(Arc::from_raw_inner(arc_slice)),
+            }
+        }
+    }
+}
+
+impl<H, T> Clone for ThinArcList<H, T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<H, T> Clone for ThinArcItem<H, T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        mem::forget(self.with_parent(ThinArcList::clone));
+        Self {
+            ptr: self.ptr,
+            phantom: self.phantom,
+        }
+    }
+}
+
+impl<H, T> Drop for ThinArcItem<H, T> {
+    #[inline]
+    fn drop(&mut self) {
+        let _ = unsafe { self.ref_into_parent() };
+    }
+}
+
+pub mod wake {
+    use super::*;
+    use core::task::{RawWaker, Waker};
+
+    pub trait ThinItemWake<H>: Sized {
+        fn wake(this: ThinArcItem<H, Self>) {
+            Self::wake_by_ref(&this);
+        }
+
+        fn wake_by_ref(this: &ThinArcItem<H, Self>);
+    }
+
+    #[cfg(target_has_atomic = "ptr")]
+    impl<H, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for Waker {
+        /// Use a [`Wake`]-able type as a `Waker`.
+        ///
+        /// No heap allocations or atomic operations are used for this conversion.
+        fn from(waker: ThinArcItem<H, W>) -> Waker {
+            // SAFETY: This is safe because raw_waker safely constructs
+            // a RawWaker from ThinArcItem<H, W>.
+            unsafe { Waker::from_raw(raw_waker(waker)) }
+        }
+    }
+
+    #[cfg(target_has_atomic = "ptr")]
+    impl<H, W: ThinItemWake<H> + Send + Sync + 'static> From<ThinArcItem<H, W>> for RawWaker {
+        /// Use a `Wake`-able type as a `RawWaker`.
+        ///
+        /// No heap allocations or atomic operations are used for this conversion.
+        fn from(waker: ThinArcItem<H, W>) -> RawWaker {
+            raw_waker(waker)
+        }
+    }
+
+    // NB: This private function for constructing a RawWaker is used, rather than
+    // inlining this into the `From<ThinArcItem<H, W>> for RawWaker` impl, to ensure that
+    // the safety of `From<ThinArcItem<H, W>> for Waker` does not depend on the correct
+    // trait dispatch - instead both impls call this function directly and
+    // explicitly.
+    #[cfg(target_has_atomic = "ptr")]
+    #[inline(always)]
+    fn raw_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(
+        waker: ThinArcItem<H, W>,
+    ) -> RawWaker {
+        use core::{
+            ptr::NonNull,
+            task::{RawWaker, RawWakerVTable},
+        };
+
+        // Increment the reference count of the arc to clone it.
+        //
+        // The #[inline(always)] is to ensure that raw_waker and clone_waker are
+        // always generated in the same code generation unit as one another, and
+        // therefore that the structurally identical const-promoted RawWakerVTable
+        // within both functions is deduplicated at LLVM IR code generation time.
+        // This allows optimizing Waker::will_wake to a single pointer comparison of
+        // the vtable pointers, rather than comparing all four function pointers
+        // within the vtables.
+        #[inline(always)]
+        unsafe fn clone_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(
+            waker: *const (),
+        ) -> RawWaker {
+            let waker_ref = unsafe {
+                ManuallyDrop::new(ThinArcItem::<H, W> {
+                    ptr: NonNull::new_unchecked(waker.cast::<WithOffset<W>>().cast_mut()),
+                    phantom: PhantomData,
+                })
+            };
+            let _clone = ManuallyDrop::new(waker_ref.clone());
+
+            RawWaker::new(
+                waker,
+                &RawWakerVTable::new(
+                    clone_waker::<H, W>,
+                    wake::<H, W>,
+                    wake_by_ref::<H, W>,
+                    drop_waker::<H, W>,
+                ),
+            )
+        }
+
+        // Wake by value, moving the Arc into the Wake::wake function
+        unsafe fn wake<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: *const ()) {
+            let waker = unsafe {
+                ThinArcItem::<H, W> {
+                    ptr: NonNull::new_unchecked(waker.cast::<WithOffset<W>>().cast_mut()),
+                    phantom: PhantomData,
+                }
+            };
+            <W as ThinItemWake<H>>::wake(waker);
+        }
+
+        // Wake by reference, wrap the waker in ManuallyDrop to avoid dropping it
+        unsafe fn wake_by_ref<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: *const ()) {
+            let waker = unsafe {
+                ManuallyDrop::new(ThinArcItem::<H, W> {
+                    ptr: NonNull::new_unchecked(waker.cast::<WithOffset<W>>().cast_mut()),
+                    phantom: PhantomData,
+                })
+            };
+            <W as ThinItemWake<H>>::wake_by_ref(&waker);
+        }
+
+        // Decrement the reference count of the Arc on drop
+        unsafe fn drop_waker<H, W: ThinItemWake<H> + Send + Sync + 'static>(waker: *const ()) {
+            let _ = unsafe {
+                ThinArcItem::<H, W> {
+                    ptr: NonNull::new_unchecked(waker.cast::<WithOffset<W>>().cast_mut()),
+                    phantom: PhantomData,
+                }
+            };
+        }
+
+        RawWaker::new(
+            ManuallyDrop::new(waker).ptr.as_ptr().cast(),
+            &RawWakerVTable::new(
+                clone_waker::<H, W>,
+                wake::<H, W>,
+                wake_by_ref::<H, W>,
+                drop_waker::<H, W>,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Introduce `ThinArcList`. It's like `ThinArc` for slices, but offers a hack to get owned handles to each item in the list (known as `ThinArcItem`). Since these items share the same object, they also allow reconstructing the `ThinArcList` from the item.

Importantly, `ThinArcItem` is pointer-sized, so I've also supplied a `ThinItemWake` construction - as needed by `futures-buffered`.

API still TBD.